### PR TITLE
Stop removed leagues from surviving into the manifest

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3554,6 +3554,7 @@
       provider.selectedSports = [...getVisibleSports(provider)];
       const idx = provider.selectedSports.indexOf(sport);
       if (idx !== -1) provider.selectedSports.splice(idx, 1);
+      if (provider.sportCategories) delete provider.sportCategories[sport];
       renderActiveProviderPanel();
       markDashboardDirty();
     }


### PR DESCRIPTION
Removing a league from Leagues & Sources only dropped it from selectedSports (which just drives what's visible in the UI). It left provider.sportCategories[sport] untouched, and the manifest builder derives catalog membership solely from non-empty sportCategories entries - so a removed league (especially one seeded by a stock preset, which always populates real category ids) kept showing up.